### PR TITLE
docs: add CLAUDE.md and refresh README for the globe résumé

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md
+
+Guidance for working in this repo. Read this before making changes.
+
+## What this is
+
+`chriscancodethat.xyz` — Chris Williams' personal site, built as an **interactive
+WebGL globe résumé**. The home page renders a particle-sampled 3D Earth (via
+react-three-fiber) with amber pins for the cities Chris has worked in. Hovering or
+selecting a city opens a retro-terminal overlay listing that city's companies;
+each company opens a CV popover. A boot-sequence intro and a full-résumé panel
+complete the "developer terminal" aesthetic.
+
+It is a **single static site** (no backend, no blog). Everything is driven from
+one data file.
+
+## Stack
+
+- **[Astro](https://astro.build) v6** — `output: 'static'`, ships zero JS except
+  the one hydrated island.
+- **React 19** — only the globe is hydrated, via `client:only="react"` (it's
+  pure WebGL, nothing to SSR).
+- **[react-three-fiber](https://r3f.docs.pmnd.rs) + [drei](https://github.com/pmndrs/drei)
+  + [postprocessing](https://github.com/pmndrs/postprocessing)** — the 3D scene,
+  controls (`OrbitControls`), and bloom.
+- **[three.js](https://threejs.org)** (`^0.184`) — underlying engine.
+- **TypeScript**, **Sass** (`src/styles/global.scss`), **CSS Modules** for
+  component-scoped styles.
+- **Fonts** via `@fontsource`: JetBrains Mono (body/terminal) + Orbitron (display).
+
+## Architecture
+
+```
+src/
+  data/resume.ts          ← SINGLE SOURCE OF TRUTH (see below)
+  pages/index.astro       home page: mounts <GlobeScene> + a static SEO fallback
+  layouts/Base.astro      <html> shell, fonts, SEO/OG meta
+  components/
+    globe/
+      GlobeScene.tsx      orchestrator: Canvas, state, all overlays. The entry point.
+      Earth.tsx           particle-sampled landmass (samples earth-water.png mask)
+      CityPin.tsx         a hover/selectable amber pin + billboard label
+      Graticule.tsx       lat/lng grid lines ("developer grid" look)
+      hooks/latLngToVec3.ts   geo→3D conversion + shared GLOBE_RADIUS
+    ui/                   the terminal-styled DOM overlays (HTML, not in-canvas):
+      BootSequence.tsx    typewriter intro, runs once
+      TerminalOverlay.tsx shared CRT window chrome (title bar, BlinkingCursor)
+      CompanyList.tsx     companies for the hovered/selected city
+      CompanyPopover.tsx  one company's full CV detail
+      FullResumePanel.tsx the "view full résumé" slide-out
+      AwardsFooter.tsx    awards + contact/socials footer, résumé toggle
+  styles/global.scss      global styles + CSS custom properties
+public/
+  CNAME                   custom domain (chriscancodethat.xyz) — do not delete
+  textures/earth-water.png   land/water mask sampled by Earth.tsx
+  images/og-image.jpg     Open Graph / Twitter card image
+  fonts/, favicon.ico
+```
+
+### `src/data/resume.ts` is the single source of truth
+
+`cities`, `skills`, `awards`, and `contact` drive **everything** — the 3D pins,
+the terminal company lists, the CV popovers, the full-résumé panel, AND the static
+SEO fallback in `index.astro`. To update résumé content, edit this file only;
+don't hardcode résumé data in components. Cities are keyed by `id` (`mia`, `lon`,
+`nyc`, `dc`). A company can be `remote` or a `placeholder` ("COMING SOON") stub.
+
+### SEO fallback
+
+`index.astro` renders a plain, crawlable HTML résumé (`.seo-fallback`) below the
+canvas. The globe is `client:only`, so this fallback is what search engines and
+no-WebGL clients see. Keep it in sync with `resume.ts` (it already maps over the
+same data).
+
+### Conventions worth matching
+
+- The globe is the only hydrated island — keep new interactivity inside it or as
+  another small island; don't ship JS site-wide.
+- Respect `prefers-reduced-motion` (auto-rotation, pin pulse, and bloom all gate
+  on it — see `usePrefersReducedMotion` in `GlobeScene.tsx`).
+- Perf heuristics already exist: bloom is skipped on small/low-core devices, and
+  `Earth.tsx` halves its particle sample count on mobile. Follow that pattern for
+  anything expensive.
+- Amber (`#ffb000`) is the accent throughout — the "terminal" theme color.
+
+## Commands
+
+```bash
+npm install
+npm run dev      # astro dev → http://localhost:4321
+npm run build    # static output to dist/
+npm run preview  # serve the production build
+npm run check    # astro check — ⚠️ see warning below
+```
+
+> ⚠️ **`npm run check` (astro check) OOMs** — it crashes the Node heap on this
+> machine. Use `npm run build` (or `tsc`) to type-check instead.
+
+## Deploy
+
+Pushing to **`main`** triggers `.github/workflows/deploy.yml`, which builds with
+`withastro/action@v6` and publishes `dist/` to **GitHub Pages** (Actions-based
+deploy, not branch-based). The custom domain is preserved via `public/CNAME`.
+
+The repo's Pages source must be set to **"GitHub Actions"** (Settings → Pages).
+If the site isn't updating despite green workflow runs, this is the first thing
+to check.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # chriscancodethat.xyz
 
-Personal site for Chris Williams. The home page is an interactive WebGL particle
-effect (Three.js + custom GLSL shaders); the rest is a content site (about, blog).
+Personal site for Chris Williams — an **interactive WebGL globe résumé**. The home
+page is a particle-sampled 3D Earth (react-three-fiber + Three.js) with amber pins
+for the cities Chris has worked in. Hover or click a city to open a retro-terminal
+overlay of its companies; each company opens a CV detail. A boot-sequence intro
+and a full-résumé panel round out the "developer terminal" aesthetic.
 
 ## Stack
 
-- **[Astro](https://astro.build)** — content-first, ships ~zero JS by default
-- **TypeScript**
-- **[Three.js](https://threejs.org)** — the particle system runs as a vanilla-TS
-  island in `src/scripts/webgl/`
-- **GSAP 3** — intro/outro tweens
-- **GLSL** shaders in `src/shaders/` (loaded via `vite-plugin-glsl`)
-- **Sass** for global styles
+- **[Astro](https://astro.build) v6** — static output, ships ~zero JS by default
+- **React 19** — only the globe is hydrated, via `client:only="react"`
+- **[react-three-fiber](https://r3f.docs.pmnd.rs)** + **[drei](https://github.com/pmndrs/drei)**
+  + **[postprocessing](https://github.com/pmndrs/postprocessing)** — 3D scene, controls, bloom
+- **[Three.js](https://threejs.org)** — underlying WebGL engine
+- **TypeScript**, **Sass** + **CSS Modules**
+- **Fonts** via `@fontsource`: JetBrains Mono + Orbitron
 
 ## Develop
 
@@ -22,23 +25,30 @@ npm run build    # static output to dist/
 npm run preview  # preview the production build
 ```
 
+> `npm run check` (astro check) currently OOMs — use `npm run build` to type-check.
+
 ## Project layout
 
 ```
-public/        static assets (CNAME, favicon, images/) copied verbatim
 src/
-  pages/       index.astro (particle canvas), about.astro, blog/
-  layouts/     Base.astro
-  components/  Nav.astro
-  content/     blog/*.md  (+ src/content.config.ts schema)
-  scripts/     App.ts + webgl/  (Three.js particle system)
-  shaders/     particle.vert / .frag + lib/
-  styles/      global.scss
+  data/resume.ts      single source of truth — cities, companies, skills, awards, contact
+  pages/              index.astro (globe + static SEO fallback)
+  layouts/            Base.astro (shell, fonts, SEO/OG meta)
+  components/
+    globe/            GlobeScene + Earth, CityPin, Graticule (the 3D scene)
+    ui/               terminal-styled overlays (boot, company list, popovers, footer)
+  styles/             global.scss
+public/               CNAME, textures/, images/, fonts/, favicon  (copied verbatim)
 ```
+
+**Editing résumé content?** Edit `src/data/resume.ts` only — it drives the 3D
+pins, the terminal overlays, *and* the static SEO fallback.
 
 ## Deploy
 
-Pushing to `master` triggers `.github/workflows/deploy.yml`, which builds with
-`withastro/action` and publishes to GitHub Pages. The custom domain is preserved
-via `public/CNAME`. Pages source must be set to **"GitHub Actions"** in the repo
-settings (Settings → Pages).
+Pushing to `main` triggers `.github/workflows/deploy.yml`, which builds with
+`withastro/action` and publishes to GitHub Pages (Actions-based deploy). The custom
+domain is preserved via `public/CNAME`. The Pages source must be set to **"GitHub
+Actions"** in repo settings (Settings → Pages).
+
+See [CLAUDE.md](./CLAUDE.md) for fuller architecture notes.


### PR DESCRIPTION
Adds a `CLAUDE.md` architecture guide for the site: stack (Astro v6 + React 19 + react-three-fiber/Three.js), file layout, the `src/data/resume.ts` single-source-of-truth, conventions, the `astro check` OOM caveat, and the GitHub Pages deploy. Rewrites the stale `README.md`, which still described the old vanilla-TS particle system, about/blog pages, GSAP, and a `master`-branch deploy, to match the current WebGL globe résumé. Docs only — no code changes.