### PR TITLE
Change site favicon to UFO emoji

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -39,7 +39,7 @@ const ogImage = new URL("/images/og-image.jpg", Astro.site);
     <link rel="canonical" href={canonical} />
     <link
       rel="icon"
-      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>"
+      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🛸</text></svg>"
     />
 
     <!-- Open Graph -->


### PR DESCRIPTION
Swaps the inline SVG favicon in `src/layouts/Base.astro` from the rocket 🚀 to the UFO 🛸 emoji. No asset rebuild is needed since the icon is a data URI.