### PR TITLE
SEO/AI/Core Web Vitals optimization

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,12 +1,13 @@
 import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
+import sitemap from '@astrojs/sitemap';
 
 // https://astro.build/config
 export default defineConfig({
   site: 'https://chriscancodethat.xyz',
   // Custom domain serves from the root, so no `base` is needed.
   output: 'static',
-  integrations: [react()],
+  integrations: [react(), sitemap()],
   vite: {
     // Force Vite to pre-bundle React so the dev server exposes the
     // `createRoot` named export from the CJS `react-dom/client`. The

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@astrojs/react": "^4.4.0",
+        "@astrojs/sitemap": "^3.7.3",
         "@fontsource/jetbrains-mono": "^5.2.6",
         "@fontsource/orbitron": "^5.2.8",
         "@react-three/drei": "^10.0.0",
@@ -735,6 +736,17 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
+      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -3218,6 +3230,15 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/@types/offscreencanvas": {
       "version": "2019.7.3",
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
@@ -3249,6 +3270,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/stats.js": {
@@ -3514,6 +3544,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -6763,6 +6799,25 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -6818,6 +6873,12 @@
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
       "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
     "node_modules/string-width": {
@@ -7115,6 +7176,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@astrojs/react": "^4.4.0",
+    "@astrojs/sitemap": "^3.7.3",
     "@fontsource/jetbrains-mono": "^5.2.6",
     "@fontsource/orbitron": "^5.2.8",
     "@react-three/drei": "^10.0.0",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,63 @@
+# robots.txt for chriscancodethat.xyz
+# Public résumé site — crawling and AI ingestion are explicitly welcome.
+
+# Reputable search-engine crawlers
+User-agent: *
+Allow: /
+
+# AI / LLM answer-engine crawlers (welcomed for résumé visibility)
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+Sitemap: https://chriscancodethat.xyz/sitemap-index.xml

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,9 +1,11 @@
 ---
-import "@fontsource/jetbrains-mono";
+// Only the font weights actually rendered in the DOM are imported (cuts
+// render-blocking CSS + font downloads). JetBrains Mono: 400 (body), 500
+// (.company / .awardLink). Orbitron (display headings): 600 + 700. The
+// in-canvas CityPin label uses a separate self-hosted public/fonts/*.woff.
+import "@fontsource/jetbrains-mono/400.css";
 import "@fontsource/jetbrains-mono/500.css";
-import "@fontsource/jetbrains-mono/700.css";
-import "@fontsource/orbitron/400.css";
-import "@fontsource/orbitron/500.css";
+import "@fontsource/orbitron/600.css";
 import "@fontsource/orbitron/700.css";
 import "../styles/global.scss";
 
@@ -15,13 +17,15 @@ interface Props {
 }
 
 const {
-  title = "Chris Williams — Interactive Globe Résumé",
-  description = "An interactive WebGL globe résumé — the cities and companies of Chris Williams, full-stack senior software engineer.",
+  title = "Chris Williams — Senior Software Engineer (React, Three.js, WebXR, AI)",
+  description = "Chris Williams is a senior software engineer in Miami, FL specializing in React, TypeScript, Three.js / WebGL, WebXR and AI/agentic systems. Explore his work history as an interactive 3D globe résumé.",
   bodyClass = "",
 } = Astro.props;
 
 const canonical = new URL(Astro.url.pathname, Astro.site);
 const ogImage = new URL("/images/og-image.jpg", Astro.site);
+const ogImageAlt =
+  "Interactive WebGL globe résumé for Chris Williams, senior software engineer.";
 ---
 
 <!doctype html>
@@ -36,7 +40,15 @@ const ogImage = new URL("/images/og-image.jpg", Astro.site);
       content="chris williams, software engineer, resume, webgl, react three fiber, three.js, interactive, portfolio, globe"
     />
     <meta name="author" content="Chris Williams" />
+    <meta name="robots" content="index, follow, max-image-preview:large" />
+    <meta name="theme-color" content="#05070a" />
     <link rel="canonical" href={canonical} />
+    <!--
+      No manual <link rel="preload"> for the body font: @fontsource emits a
+      content-hashed filename per build, so a hardcoded path would 404 (and
+      regress, not help). The bundled CSS references it early, and .gl-root
+      paints its gradient immediately for a fast LCP.
+    -->
     <link
       rel="icon"
       href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🛸</text></svg>"
@@ -48,12 +60,22 @@ const ogImage = new URL("/images/og-image.jpg", Astro.site);
     <meta property="og:url" content={canonical} />
     <meta property="og:description" content={description} />
     <meta property="og:type" content="website" />
+    <meta property="og:locale" content="en_US" />
     <meta property="og:image" content={ogImage} />
     <meta property="og:image:type" content="image/jpeg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="1097" />
+    <meta property="og:image:alt" content={ogImageAlt} />
 
     <!-- Twitter card -->
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
+    <meta name="twitter:image:alt" content={ogImageAlt} />
+
+    <!-- Page-specific head (e.g. JSON-LD structured data) -->
+    <slot name="head" />
   </head>
   <body class={bodyClass}>
     <slot />

--- a/src/lib/structuredData.ts
+++ b/src/lib/structuredData.ts
@@ -1,0 +1,167 @@
+// Builds schema.org JSON-LD for the home page from the résumé single source of
+// truth (`src/data/resume.ts`). Keeping the generation here means the structured
+// data stays in sync with the visible/crawlable content automatically.
+
+import { cities, skills, awards, contact, type City, type Company } from '../data/resume';
+
+/** City id → human-readable address parts for `worksFor`/`alumniOf` location. */
+const CITY_ADDRESS: Record<string, { locality: string; region?: string; country: string }> = {
+  mia: { locality: 'Miami', region: 'FL', country: 'US' },
+  lon: { locality: 'London', country: 'GB' },
+  nyc: { locality: 'New York', region: 'NY', country: 'US' },
+  dc: { locality: 'Washington', region: 'DC', country: 'US' },
+};
+
+/** Heuristic: is this résumé entry an education record (→ alumniOf) vs. a job? */
+function isEducation(company: Company): boolean {
+  return (
+    company.dates.toLowerCase() === 'education' ||
+    /\buniversity\b|\bcollege\b|general assembly/i.test(company.name)
+  );
+}
+
+/** Parse a "2023–Present" / "2021–2023" range into ISO-ish start/end years. */
+function parseDates(dates: string): { start?: string; end?: string } {
+  const match = dates.match(/(\d{4})\s*[–-]\s*(present|\d{4})/i);
+  if (!match) return {};
+  const [, start, rawEnd] = match;
+  const end = /present/i.test(rawEnd) ? undefined : rawEnd;
+  return { start, end };
+}
+
+function postalAddress(cityId: string) {
+  const addr = CITY_ADDRESS[cityId];
+  if (!addr) return undefined;
+  return {
+    '@type': 'PostalAddress',
+    addressLocality: addr.locality,
+    ...(addr.region ? { addressRegion: addr.region } : {}),
+    addressCountry: addr.country,
+  };
+}
+
+/** An Organization node for a job, with optional location + homepage. */
+function organization(company: Company, city: City) {
+  const address = postalAddress(city.id);
+  return {
+    '@type': 'Organization',
+    name: company.name,
+    ...(company.url ? { url: company.url } : {}),
+    ...(address ? { address } : {}),
+  };
+}
+
+/** EducationalOrganization node for alumniOf entries. */
+function educationalOrganization(company: Company, city: City) {
+  const address = postalAddress(city.id);
+  return {
+    '@type': 'EducationalOrganization',
+    name: company.name,
+    ...(address ? { address } : {}),
+  };
+}
+
+interface FlatRole {
+  company: Company;
+  city: City;
+  start?: string;
+  end?: string;
+  isCurrent: boolean;
+}
+
+function buildPerson() {
+  const jobs: FlatRole[] = [];
+  const education: { company: Company; city: City }[] = [];
+
+  for (const city of cities) {
+    for (const company of city.companies) {
+      if (company.placeholder) continue;
+      if (isEducation(company)) {
+        education.push({ company, city });
+        continue;
+      }
+      const { start, end } = parseDates(company.dates);
+      jobs.push({
+        company,
+        city,
+        start,
+        end,
+        isCurrent: /present/i.test(company.dates),
+      });
+    }
+  }
+
+  // Current role drives `worksFor`; everything else (incl. past) becomes a
+  // `hasOccupation` entry so the full work history is machine-readable.
+  const current = jobs.find((j) => j.isCurrent);
+
+  const hasOccupation = jobs.map((j) => ({
+    '@type': 'Occupation' as const,
+    name: j.company.title,
+    ...(j.company.summary ? { description: j.company.summary } : {}),
+    occupationLocation: postalAddress(j.city.id) ?? undefined,
+    estimatedSalary: undefined, // omitted; schema allows optional
+    skills: j.company.tech.length ? j.company.tech.join(', ') : undefined,
+  }));
+
+  const knowsAbout = Array.from(
+    new Set(skills.flatMap((group) => group.items)),
+  );
+
+  const sameAs = contact.socials.map((s) => s.href);
+
+  const person = {
+    '@type': 'Person',
+    '@id': 'https://chriscancodethat.xyz/#person',
+    name: contact.name,
+    jobTitle: current ? current.company.title : contact.role,
+    email: `mailto:${contact.email}`,
+    telephone: contact.phone,
+    url: 'https://chriscancodethat.xyz/',
+    address: {
+      '@type': 'PostalAddress',
+      addressLocality: 'Miami',
+      addressRegion: 'FL',
+      addressCountry: 'US',
+    },
+    sameAs,
+    knowsAbout,
+    ...(current
+      ? { worksFor: organization(current.company, current.city) }
+      : {}),
+    hasOccupation: stripUndefined(hasOccupation),
+    alumniOf: education.map((e) => educationalOrganization(e.company, e.city)),
+    award: awards.map((a) => a.title),
+  };
+
+  return stripUndefined(person);
+}
+
+/** Recursively drop `undefined` values / empty objects so JSON-LD stays clean. */
+function stripUndefined<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(stripUndefined) as unknown as T;
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (v === undefined) continue;
+      out[k] = stripUndefined(v);
+    }
+    return out as T;
+  }
+  return value;
+}
+
+/** Full ProfilePage graph wrapping the Person, for the home page <head>. */
+export function buildProfilePageJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ProfilePage',
+    '@id': 'https://chriscancodethat.xyz/#profilepage',
+    url: 'https://chriscancodethat.xyz/',
+    name: `${contact.name} — ${contact.role}`,
+    dateModified: new Date().toISOString().slice(0, 10),
+    mainEntity: buildPerson(),
+  };
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,8 +2,17 @@
 import Base from "../layouts/Base.astro";
 import GlobeScene from "../components/globe/GlobeScene.tsx";
 import { cities, awards, contact } from "../data/resume";
+import { buildProfilePageJsonLd } from "../lib/structuredData";
+
+const jsonLd = buildProfilePageJsonLd();
 ---
 <Base bodyClass="is-home">
+  <Fragment slot="head">
+    <script
+      type="application/ld+json"
+      set:html={JSON.stringify(jsonLd)}
+    />
+  </Fragment>
   <div class="gl-root">
     <GlobeScene client:only="react" />
   </div>


### PR DESCRIPTION
Optimizes the globe résumé for search engines, AI answer-engines, and Core Web Vitals — all driven from `resume.ts` so it stays in sync. Adds a sitemap (`@astrojs/sitemap`), a `robots.txt` that welcomes search and major AI crawlers, and `ProfilePage`→`Person` JSON-LD (8 occupations, 27 skills, `worksFor`/`alumniOf`/`award`/`sameAs`) injected via a new `head` slot. Completes the social/search meta (Twitter title/description, `og:image` dimensions + alt, `og:locale`, `robots`, `theme-color`). Trims font CSS from 6 imports to the 4 weights actually rendered, which also fixes a previously-missing Orbitron 600 import. Build passes and the sitemap/JSON-LD/meta were verified in `dist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)