### PR TITLE
Fix mobile overlap: dock company list above status footer

### DIFF
--- a/src/components/ui/AwardsFooter.tsx
+++ b/src/components/ui/AwardsFooter.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import type { Award, Social } from '../../data/resume';
 import styles from './AwardsFooter.module.css';
 
@@ -33,8 +34,31 @@ export function AwardsFooter({
   onResumeToggle,
   resumeOpen,
 }: AwardsFooterProps) {
+  const barRef = useRef<HTMLElement>(null);
+
+  // Expose the footer's live height as --footer-height so other fixed overlays
+  // (e.g. the mobile company-list dock) can sit above it instead of underneath.
+  useEffect(() => {
+    const el = barRef.current;
+    if (!el || typeof document === 'undefined') return;
+    const root = document.documentElement;
+    const apply = () =>
+      root.style.setProperty('--footer-height', `${el.offsetHeight}px`);
+    apply();
+
+    const ro =
+      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(apply) : null;
+    ro?.observe(el);
+    window.addEventListener('resize', apply);
+    return () => {
+      ro?.disconnect();
+      window.removeEventListener('resize', apply);
+      root.style.removeProperty('--footer-height');
+    };
+  }, []);
+
   return (
-    <footer className={styles.bar} aria-label="Résumé status bar">
+    <footer ref={barRef} className={styles.bar} aria-label="Résumé status bar">
       <div className={styles.left}>
         <span className={styles.name}>{contact.name}</span>
         <span className={styles.sep} aria-hidden="true">

--- a/src/components/ui/CompanyList.module.css
+++ b/src/components/ui/CompanyList.module.css
@@ -112,23 +112,23 @@
   white-space: nowrap;
 }
 
-/* Full-width bottom sheet on mobile. */
+/* Full-width bottom sheet on mobile — docked directly above the status footer
+   (whose live height is published as --footer-height) so the two never overlap. */
 @media (max-width: 767px) {
   .dock {
     left: 0;
     right: 0;
-    bottom: 0;
+    bottom: var(--footer-height, 0px);
     width: 100%;
-    max-height: 50vh;
+    max-height: calc(50vh - var(--footer-height, 0px));
   }
 
   .panel {
     border-radius: 8px 8px 0 0;
-    border-bottom: none;
-    max-height: 50vh;
+    max-height: 100%;
   }
 
   .list {
-    max-height: calc(50vh - 90px);
+    max-height: calc(50vh - var(--footer-height, 0px) - 90px);
   }
 }


### PR DESCRIPTION
On mobile, the company-list dock (the city "experience" pop-up) and the status footer were both pinned to `bottom: 0`, so the footer's higher z-index covered the pop-up's rows. The footer now publishes its live height as a `--footer-height` CSS variable via `ResizeObserver`, and the dock offsets its `bottom` and `max-height` by that value so the two no longer overlap. An earlier experimental globe atmosphere/lighting change was reverted, so this branch contains only the overlap fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)