### PR TITLE
Fix duplicated GWU education line and long-slug wrapping

### DIFF
--- a/src/components/ui/CompanyList.module.css
+++ b/src/components/ui/CompanyList.module.css
@@ -3,7 +3,7 @@
   left: 24px;
   bottom: 64px;
   z-index: 20;
-  width: min(380px, calc(100vw - 48px));
+  width: min(420px, calc(100vw - 48px));
   max-height: 60vh;
   display: flex;
 }
@@ -54,7 +54,8 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 12px;
+  flex-wrap: wrap;
+  gap: 2px 12px;
   width: 100%;
   padding: 6px 8px;
   border-radius: 4px;
@@ -83,9 +84,11 @@
 .rowMain {
   display: inline-flex;
   align-items: baseline;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  flex: 1 1 auto;
   gap: 6px;
   min-width: 0;
+  white-space: nowrap;
 }
 
 .arrow {

--- a/src/data/resume.ts
+++ b/src/data/resume.ts
@@ -148,8 +148,7 @@ export const cities: City[] = [
         name: 'The George Washington University',
         title: 'Columbian College of Arts & Sciences — Political Science & Government',
         dates: '2005–2009',
-        summary:
-          'Political Science & Government, Columbian College of Arts & Sciences.',
+        summary: '',
         tech: [],
       },
     ],


### PR DESCRIPTION
Removes the redundant summary on the George Washington University education entry, which simply repeated the degree title shown above it. Also keeps long company slugs (like `open ./the-george-washington-university`) on a single unbroken line in the city company list — the dates now reflow below the name instead of forcing an ugly mid-word break, and the dock is slightly wider for breathing room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)